### PR TITLE
update beaker collision offsets

### DIFF
--- a/labware/beaker500ml/beaker-500ml-inst.usda
+++ b/labware/beaker500ml/beaker-500ml-inst.usda
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:179bca27fe17f7a8fa3df24a06515cb11f0cb42221ebba6ae42f37b33e9636d1
-size 7452
+oid sha256:806559fc6fef9c99d5ab52ef34bd51eeecf702dacf387716418664f9136efb47
+size 8035

--- a/labware/beaker500ml/beaker-500ml-inst.usda
+++ b/labware/beaker500ml/beaker-500ml-inst.usda
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09a0099a94733be9f98830592a7be092743349154aa66fe593922a1027083ee1
-size 5140
+oid sha256:179bca27fe17f7a8fa3df24a06515cb11f0cb42221ebba6ae42f37b33e9636d1
+size 7452

--- a/labware/beaker500ml/beaker-500ml.usda
+++ b/labware/beaker500ml/beaker-500ml.usda
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b640b83a18dea6e07140ed012fa260e1fb8c92240e83882556035479cdd8781f
-size 5016
+oid sha256:ccdf75ac0f9d7ceb9bd61130891b0a56d99546a4f4c201602f1d834956e94f48
+size 6782

--- a/labware/beaker500ml/beaker-500ml.usda
+++ b/labware/beaker500ml/beaker-500ml.usda
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ccdf75ac0f9d7ceb9bd61130891b0a56d99546a4f4c201602f1d834956e94f48
-size 6782
+oid sha256:8fb21e867e7fd8cb5740644586fbb7ff0f7dbae77b21c00d6959b7deb8bb1887
+size 7381

--- a/labware/beaker500ml/files/beaker-500mL_mesh.usda
+++ b/labware/beaker500ml/files/beaker-500mL_mesh.usda
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2f95c5c36a984f2d0502cad263dbf980fdb34d557fc7272e0d9610d54c116825
-size 73416
+oid sha256:33bd69d5b8187243d9bbcb50fcb354ab0a463cbb29b9e13d87bce2a160c9f00a
+size 76346

--- a/labware/beaker500ml/files/materials.usda
+++ b/labware/beaker500ml/files/materials.usda
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:079dd75a9efb03e4db6f92ac98be414313fa3008b0c171c5ac7ab731589c546b
-size 2973
+oid sha256:fe20a242ac3ffab0ca24c1320c85a4f6ed0f87706261fe419806fa7ab0b831a4
+size 5882


### PR DESCRIPTION
Fix collision for  beakers as they currently clip through robot gripper.
Validated by running the pick beaker workflow with main of matterix
```
/matterix.sh -p scripts/run_workflow.py --task Matterix-Test-Beaker-Lift-Franka-v1 --workflow pickup_beaker
```