### PR TITLE
Add Fisherbrand vial asset with non-OmniGlass material

### DIFF
--- a/labware/fisherbrand_03-339-21f/files/Fisherbrand_Vial_Z_UP_FIXED.usdc
+++ b/labware/fisherbrand_03-339-21f/files/Fisherbrand_Vial_Z_UP_FIXED.usdc
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5fedf7b440f840f3dc2ac7f2ee5c653ffeea9b21ccfdbe4191e73c4d3fa6ed0
+size 735767

--- a/labware/fisherbrand_03-339-21f/files/fisherbrand_03-339-21f_z_up_fixed_mesh.usda
+++ b/labware/fisherbrand_03-339-21f/files/fisherbrand_03-339-21f_z_up_fixed_mesh.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2eb5418eb6d14ec1fd9aff8e7b6c11bd72f7b6bef12a704015045841caa1dc11
+size 1665

--- a/labware/fisherbrand_03-339-21f/fisherbrand_03-339-21f_z_up_fixed.usda
+++ b/labware/fisherbrand_03-339-21f/fisherbrand_03-339-21f_z_up_fixed.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4eb34f71ac1136aa9531879db65c3f5b0dc9253707068f92def420213b4de07b
+size 6620

--- a/labware/fisherbrand_03-339-21f/provenance/LICENSE.asset.txt
+++ b/labware/fisherbrand_03-339-21f/provenance/LICENSE.asset.txt
@@ -1,0 +1,30 @@
+Matterix Fisherbrand 03-339-21F self-modelled asset
+===========================================================
+
+Creator / copyright owner
+-------------------------
+Matterix project author (user-confirmed self-authored model).
+
+License
+-------
+This self-modelled asset is dedicated to the public domain under the Creative
+Commons CC0 1.0 Universal dedication.
+
+SPDX-License-Identifier: CC0-1.0
+License URL: https://creativecommons.org/publicdomain/zero/1.0/
+
+The model is self-modelled from the official Fisherbrand 03-339-21F product
+specification and dimensions. No Fisher CAD, mesh, texture, or product image
+was copied into this payload.
+
+Separate reference note
+----------------------
+The NIH 3D 15-Well Vial Holder record, 3DPX-000429, is a separate holder
+record. Its Public Domain label applies to that holder record, not to this
+self-modelled vial. It is cited only because its description names the
+referenced 21 x 70 mm Fisherbrand vial:
+https://3d.nih.gov/entries/3DPX-000429
+
+The NIH/ChoderaLab entry and Fisherbrand name are cited for provenance and
+identification only; they do not imply endorsement or authorship of this
+Matterix self-modelled vial asset.

--- a/labware/fisherbrand_03-339-21f/provenance/NOTICE.md
+++ b/labware/fisherbrand_03-339-21f/provenance/NOTICE.md
@@ -1,0 +1,15 @@
+# Reference Vial notice
+
+This promoted Matterix asset is a self-modelled approximation of the
+Fisherbrand 03-339-21F vial, authored from the published product specification
+and dimensions. The payload does not copy Fisher CAD, mesh, texture, or product
+images.
+
+The asset is dedicated under CC0 1.0 Universal. See LICENSE.asset.txt.
+
+The NIH 3D 15-Well Vial Holder record
+(https://3d.nih.gov/entries/3DPX-000429) is a separate holder record. Its
+Public Domain label applies to that holder, not to this self-modelled vial; it
+is cited only because its description names the referenced 21 x 70 mm vial.
+NIH, ChoderaLab, Fisher Scientific, and Fisherbrand are not authors or endorsers of
+this Matterix self-modelled asset.

--- a/labware/fisherbrand_03-339-21f/provenance/provenance.yaml
+++ b/labware/fisherbrand_03-339-21f/provenance/provenance.yaml
@@ -1,0 +1,17 @@
+asset: fisherbrand_03-339-21f
+asset_status: promoted_to_official_matterix_data
+canonical_visual_source: Fisherbrand_03-339-21F_assembled.glb
+canonical_visual_source_sha256: 4c26a920c44f512667c997a823e2f87bf2e522c17862f3eaffcfb1be42d77d28
+canonical_visual_source_relative_path: not_packaged_in_official_data
+canonical_visual_source_note: Original internal source path is retained in the Matterix_assets_internal audit record; this release contains the self-modelled USD payload only.
+creator: matterix_project_author_user_confirmed
+license_status: CC0-1.0-Universal
+redistribution_status: allowed_under_CC0-1.0-Universal
+creation_method: user_authored_self_modelled_from_official_specification_and_dimensions
+manufacturer_facts_url: https://www.fishersci.com/shop/products/class-b-clear-glass-threaded-vials-with-closures-packaged-separately/0333921H
+manufacturer_cad_or_texture_copied: false
+approximation_limit: not a manufacturing, sealing, thread-gauge, or tooling model
+license_file_relative_path: provenance/LICENSE.asset.txt
+license_url: https://creativecommons.org/publicdomain/zero/1.0/
+reference_source_url: https://3d.nih.gov/entries/3DPX-000429
+reference_source_license_label: public_domain


### PR DESCRIPTION
Adds the self-modelled Fisherbrand 03-339-21F 14.8 mL vial asset and its corresponding vial plate.

## Changes
- Adds the Fisherbrand 03-339-21F 14.8 mL vial USD asset and corresponding vial plate.
- Replaces the vial visual glass material from OmniGlass with OmniPBR. The glass rendering is still visually broken in RTX.
- Preserves the existing invisible `BodyCylinder` and `CapCylinder` collision definitions.
- Preserves the existing physics material bindings.
- Includes CC0 1.0 Universal provenance metadata.

## Tests performed
- [x] Ran vial/plate settling tests at 240 Hz for 5 s and 10 s with the current collider geometry — final holder/table clearance was `-0.087 mm`, vial tilt was `0.034°`, and post-settle drift was `0.0011 mm`.
- [x] Ran the full 17-phase pick-and-return trajectory — both gripper finger contacts were confirmed at approximately `6.07 N` and `6.25 N`.
- [x] Returned the vial to its original well — measured insertion was `35.352 mm` against a `35.35 mm` well-floor depth, with `0.139 mm` lateral error.
- [x] Measured holder disturbance during the trajectory — holder drift was `0.391 mm`.
- [x] Measured vial-to-holder contact during lift — peak contact was `2.754 N`.
- [x] Measured cap-frame residuals — cap-to-grasp residual was `1.974 mm` and pre-release cap-to-place residual was `0.559 mm`.
- [x] Ran five fresh pick-and-return cycles — all five returned the vial to `hole_middle_center` with `0.139 mm` lateral error and `35.352 mm` insertion.
- [x] Confirmed collision proxies remain invisible and the vials remain vertical and seated in the plate.

## Review requested
Please review the vial and vial-plate colliders, including their dimensions and placement, and how the vials sit within the wells.

The OmniPBR glass material should also be reviewed, as the vial glass is still not rendering correctly in RTX.