### PR TITLE
Add six reusable labware USD payloads

### DIFF
--- a/labware/corning-3025-50/corning-3025-50-inst.usda
+++ b/labware/corning-3025-50/corning-3025-50-inst.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f5f098c192f33dd2409df51d4d7d6d11a41b14021aa7da1e08ce01f11352aa48
+size 205

--- a/labware/corning-3025-50/corning-3025-50.usda
+++ b/labware/corning-3025-50/corning-3025-50.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:557b701cf0c12d04b7f6ac251b95c2283654e3ac7deef0d8e903ae0d69ac69a8
+size 4994

--- a/labware/corning-3025-50/files/corning-3025-50_collision.usda
+++ b/labware/corning-3025-50/files/corning-3025-50_collision.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01c7f24ea0256e373741c819854aac97b18143a07068073f2f52017a1fc1c2f0
+size 55914

--- a/labware/corning-3025-50/files/corning-3025-50_mesh.usda
+++ b/labware/corning-3025-50/files/corning-3025-50_mesh.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0aa1b8bc4f95418e6d181918928f18e77012e5ab281cd7a18fd5a32ef63986f
+size 93141

--- a/labware/corning-5580-100/corning-5580-100-inst.usda
+++ b/labware/corning-5580-100/corning-5580-100-inst.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b4ab38f50017df9fa51fca6681b3da14739c82fe1556a3aa3973e615f21ba65
+size 206

--- a/labware/corning-5580-100/corning-5580-100.usda
+++ b/labware/corning-5580-100/corning-5580-100.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:431fb92c275821644012d9292217a6c42cc98328f011de5b310482cc6c20d1e8
+size 4867

--- a/labware/corning-5580-100/files/corning-5580-100_collision.usda
+++ b/labware/corning-5580-100/files/corning-5580-100_collision.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e4f33eb7f12919989695c6ae1dc54652fef76442e4678d0de5997df095385b8b
+size 397401

--- a/labware/corning-5580-100/files/corning-5580-100_mesh.usda
+++ b/labware/corning-5580-100/files/corning-5580-100_mesh.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82c57f9c2b0f38e9ab574a04af513fa5ea12ec56172e6b1d8284d582f756853c
+size 2626774

--- a/labware/corning-5580-25/corning-5580-25-inst.usda
+++ b/labware/corning-5580-25/corning-5580-25-inst.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:59798dd43f9c02fe7c28162e406b1eb5d6882856b3e0d5eca87420310ea6e1ca
+size 205

--- a/labware/corning-5580-25/corning-5580-25.usda
+++ b/labware/corning-5580-25/corning-5580-25.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfbf9314e56544e0c8a9656cd12d826099c38991ac483965606bd6f97ae6f245
+size 4861

--- a/labware/corning-5580-25/files/corning-5580-25_collision.usda
+++ b/labware/corning-5580-25/files/corning-5580-25_collision.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0da9dd730314fe92ab564123028ea080d867c844fe0359d0ba9d275f8d72c14
+size 326276

--- a/labware/corning-5580-25/files/corning-5580-25_mesh.usda
+++ b/labware/corning-5580-25/files/corning-5580-25_mesh.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:20f7be6a90fccbbc933ace3fe1ba1f246744a5fc654a4294258e9bec8f44c239
+size 2640927

--- a/labware/corning-5580-50/corning-5580-50-inst.usda
+++ b/labware/corning-5580-50/corning-5580-50-inst.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:df613ad70776befaa6676c81c3e5707d78cc18964043e4fd2ef1a174c9d00252
+size 205

--- a/labware/corning-5580-50/corning-5580-50.usda
+++ b/labware/corning-5580-50/corning-5580-50.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56ef49409698e7180b7c1b6114935083a54bf2c2d459247162c49448e421e96a
+size 4863

--- a/labware/corning-5580-50/files/corning-5580-50_collision.usda
+++ b/labware/corning-5580-50/files/corning-5580-50_collision.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0a5a64df920dcbc4f839d86ece0dae987bcb30cc70fd5dfebba894c426b6e7e2
+size 364788

--- a/labware/corning-5580-50/files/corning-5580-50_mesh.usda
+++ b/labware/corning-5580-50/files/corning-5580-50_mesh.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ba2eaab882a73f6bd6650d40a0715a68624a23ff968b18dbcbdd88a88ba54dc2
+size 2633510

--- a/labware/dwk-213133202/dwk-213133202-inst.usda
+++ b/labware/dwk-213133202/dwk-213133202-inst.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dcfb9e3ce9cf152cfea1b752cdf12317bcd4083e1b43a1eb5846dc56b182c5ee
+size 203

--- a/labware/dwk-213133202/dwk-213133202.usda
+++ b/labware/dwk-213133202/dwk-213133202.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7e28d471565f92a1eefcec257445f91ccda94f8b859c35ea4bb524b46e5a00f8
+size 4865

--- a/labware/dwk-213133202/files/dwk-213133202_collision.usda
+++ b/labware/dwk-213133202/files/dwk-213133202_collision.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:56eed0e3df4803733c6ac4364a028af66077961ed899b373583643f043bade36
+size 175796

--- a/labware/dwk-213133202/files/dwk-213133202_mesh.usda
+++ b/labware/dwk-213133202/files/dwk-213133202_mesh.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6bbe7d53a47661985d71cc64ee40909050fe7e0a717e4023e2adb3dbc3e6240d
+size 2615222

--- a/labware/dwk-213133408/dwk-213133408-inst.usda
+++ b/labware/dwk-213133408/dwk-213133408-inst.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:46b89b8b0b0ade5c35654ef3daac7bce7e48654622cd6d09c70d86ac503d4fa6
+size 203

--- a/labware/dwk-213133408/dwk-213133408.usda
+++ b/labware/dwk-213133408/dwk-213133408.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4213df00b5227f9b54a83113223e2d70608b6868ddc96480e17e9f7af37191eb
+size 4853

--- a/labware/dwk-213133408/files/dwk-213133408_collision.usda
+++ b/labware/dwk-213133408/files/dwk-213133408_collision.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a71b778ad3a9aea8f49c4d42a0443aedabf1918f42a9f6531ed3bbf2593feb35
+size 176098

--- a/labware/dwk-213133408/files/dwk-213133408_mesh.usda
+++ b/labware/dwk-213133408/files/dwk-213133408_mesh.usda
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fe21a0b56bb3f0fea2d7c3dad4c7c7120b92b705700a2dfb6e28a0b7074fd1e7
+size 2611490


### PR DESCRIPTION
## Scope

Adds six reusable labware payloads under `labware/`.

Each asset folder contains only the runtime USD payloads:

- `<asset>.usda`: non-instanceable root payload with visual material, frames, and collision reference
- `<asset>-inst.usda`: instanceable wrapper
- `files/<asset>_mesh.usda`: visual mesh payload
- `files/<asset>_collision.usda`: runtime collision payload

Assets:

- corning-3025-50
- corning-5580-25
- corning-5580-50
- corning-5580-100
- dwk-213133202
- dwk-213133408

No qualification logs, results, tests, runbooks, reports, raw bundles, or workbench records are included in this asset PR.